### PR TITLE
Make errors more verbose

### DIFF
--- a/lib/votifier.js
+++ b/lib/votifier.js
@@ -36,7 +36,7 @@ Votifier.prototype.handleConnection = function(socket) {
 	socket.once("data", function(data) {
 		// check for correct block length
 		if(data.length !== 256) {
-			self.emit("error", new Error("Bad response length"));
+			self.emit("error", new Error(`Bad response length (${data.length})`));
 			socket.end("Bad response length\n");
 			socket.destroy();
 			return;
@@ -44,7 +44,8 @@ Votifier.prototype.handleConnection = function(socket) {
 		
 		// decode block
 		var decoder = self.rsa.decrypt(data);
-		decoder.once("error", function(data) {
+		decoder.once("error", function (data) {
+			console.error(data)
 			self.emit("error", new Error("Bad response content"));
 			socket.end("Bad response content\n");
 			socket.destroy();

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "version": "0.0.0",
   "author": "Jan Buschtöns <buschtoens@gmail.com>",
   "contributors": [ 
-    { "name": "Jan Buschtöns", "email": "buschtoens@gmail.com" }
+    { "name": "Jan Buschtöns", "email": "buschtoens@gmail.com" },
+    { "name": "Marcus Huber (Xenorio)", "email": "dev@xenorio.xyz" }
   ],
   "license": "MIT",
   "keywords": ["bukkit", "craftbukkit", "minecraft", "api", "wrapper", "votifier", "emulation"],


### PR DESCRIPTION
This makes the "Bad response content" and "Bad response length" errors more verbose.

I've been running into the "Bad response content" error while implementing this package somewhere and got confused as to what's going on. Eventually I just added a log of the **actual** error, which told me that I just messed up the path to the private key. Would not have figured that out otherwise.